### PR TITLE
add selection to choose QMI or MBIM mode

### DIFF
--- a/autoflash-7455.sh
+++ b/autoflash-7455.sh
@@ -116,10 +116,23 @@ printf "${BLUE}---${NC}\n"
 echo 'Reseting modem...'
 ./swi_setusbcomp.pl --usbreset --device="/dev/$devpath" &>/dev/null
 sleep 3
+
+
+read -p  'please decide if you want the modem network interface to be set to QMI (q) or MBIM (m) protocol, or press enter for default selection (MBIM)
+' answer
+
+if [ "$answer" = 'q' ]; then
+# Modem Mode Switch to usbcomp=6 (DM   NMEA  AT    QMI)
+printf "${BLUE}---${NC}\n"
+echo 'Running Modem Mode Switch to usbcomp=6 (DM   NMEA  AT    QMI)'
+./swi_setusbcomp.pl --usbcomp=6 --device="/dev/$devpath"
+else
 # Modem Mode Switch to usbcomp=8 (DM   NMEA  AT    MBIM)
 printf "${BLUE}---${NC}\n"
 echo 'Running Modem Mode Switch to usbcomp=8 (DM   NMEA  AT    MBIM)'
 ./swi_setusbcomp.pl --usbcomp=8 --device="/dev/$devpath"
+fi
+
 
 # Reset Modem
 printf "${BLUE}---${NC}\n"


### PR DESCRIPTION
QMI mode is supposed to be the best mode for these modems
at least for OpenWrt, (and also what I needed for my own setup)
I don't know about other platforms so I just added it as a choice