### PR TITLE
Change libqmi to always pull latest from repo

### DIFF
--- a/autoflash-7455.sh
+++ b/autoflash-7455.sh
@@ -81,11 +81,11 @@ yes | cpan install UUID::Tiny IPC::Shareable JSON
 
 # apt-get will fail to download minicom/qmi-utilities on LiveCD/LiveUSB without adding repositories
 # Also, if you add security.ubuntu.com bionic main universe, you'll get an older version of libqmi (1.18)
-# So we'll pull the .deb files directly
-deb_minicom='minicom_2.7.1-1_amd64.deb'
-deb_libqmi_glib5='libqmi-glib5_1.20.0-1.1ubuntu1_amd64.deb'
-deb_libqmi_proxy='libqmi-proxy_1.20.0-1.1ubuntu1_amd64.deb'
-deb_libqmi_utils='libqmi-utils_1.20.0-1.1ubuntu1_amd64.deb'
+# So we'll pull the .deb files directly with curl to always pull newest version
+deb_minicom=`curl http://security.ubuntu.com/ubuntu/pool/universe/m/minicom/ 2>/dev/null | grep -Eo '"minicom.*amd64.deb"' | tail -n1 | sed 's/\"//g'`
+deb_libqmi_glib5=`curl http://security.ubuntu.com/ubuntu/pool/main/libq/libqmi/ 2>/dev/null | grep -Eo '"libqmi-glib5.*amd64.deb"' | tail -n1 | sed 's/\"//g'`
+deb_libqmi_proxy=`curl http://security.ubuntu.com/ubuntu/pool/main/libq/libqmi/ 2>/dev/null | grep -Eo '"libqmi-proxy.*amd64.deb"' | tail -n1 | sed 's/\"//g'`
+deb_libqmi_utils=`curl http://security.ubuntu.com/ubuntu/pool/universe/libq/libqmi/ 2>/dev/null | grep -Eo '"libqmi-utils.*amd64.deb"' | tail -n1 | sed 's/\"//g'`
 if [ ! -f $deb_minicom ]; then
     wget http://security.ubuntu.com/ubuntu/pool/universe/m/minicom/$deb_minicom
     dpkg -i $deb_minicom


### PR DESCRIPTION
Swapped variables to just curl the repo and select the latest amd64 version.

Needs testing and review.