### PR TITLE
Refactor script to make it modular and support switches and options.

### DIFF
--- a/autoflash-7455.sh
+++ b/autoflash-7455.sh
@@ -27,106 +27,203 @@
 # https://github.com/danielewood/sierra-wireless-modems
 
 #.VERSION
-# Version: 20190618
+# Version: master
 
+
+#echo "Starting sctipt $0"
+display_usage() {
+  echo
+  echo "Usage: $0"
+  echo
+  echo "Modem Modes"
+  echo " -h    Display usage instructions"
+  echo " -u    Set AT!USBSPEED"
+  echo "         0 - High Speed USB 2 [Default]"
+  echo "         1 - SuperSpeed USB 3"
+  echo " -m    Set AT!USBCOMP"
+  echo "         8 - MBIM mode (diag,nmea,modem,mbim) [Default]"
+  echo "         6 - QMI mode (diag,nmea,modem,rmnet0)"
+  echo " -b    Set AT!SELRAT and AT!BAND"
+  echo "         9 - LTE Only [Default]"  
+  echo "         0 - All Bands"  
+  echo " -e    Set AT!FASTENUMEN"
+  echo "         0 - Disable fast enumeration"
+  echo "         1 - Enable fast enumeration for cold boot and disable for warm boot"
+  echo "         2 - Enable fast enumeration for warm boot and disable for cold boot [Default]"
+  echo "         3 - Enable fast enumeration for warm and cold boot"
+  echo
+  echo "Script Modes:"
+  echo " -a    Enable All Script Functions [Default]"
+  echo "         Same as: $0 -Mgcdfs"
+  echo " -M    Use swi_setusbcomp.pl to set modem composition"
+  echo " -g    Display Modem Settings"
+  echo " -c    Clear Existing Modem Firmwares"
+  echo " -d    Download Modem Firmware"
+  echo " -f    Flash Modem Firmware"
+  echo " -s    Change Modem Settings/Modes"
+  echo " -l    Legacy Stable Firmware"
+  echo '         Set SWI9X30C_ZIP="SWI9X30C_02.30.01.01_GENERIC_002.045_001.zip"'
+  echo " -q    Quiet Mode -- suppress most output"
+  echo " -v    Legacy Stable Firmware"
+  echo
+  exit 0
+}
+
+raise_error() {
+  local error_message="$@"
+  echo "${error_message}" 1>&2;
+}
+
+while getopts hu:m:b:e:Mgcdfsalqv option
+do
+ case "${option}"
+ in
+ h) display_usage;;
+ u) AT_USBSPEED=${OPTARG};;
+ m) AT_USBCOMP=${OPTARG};;
+ b) AT_SELRAT=${OPTARG};;
+ e) AT_FASTENUMEN=${OPTARG};;
+ M) set_swi_setusbcomp_trigger=1;;
+ g) get_modem_settings_trigger=1;;
+ c) clear_modem_firmware_trigger=1;;
+ d) download_modem_firmware_trigger=1;;
+ f) flash_modem_firmware_trigger=1;;
+ s) set_modem_settings_trigger=1;;
+ a) all_functions_trigger=1;;
+ l) SWI9X30C_ZIP='SWI9X30C_02.30.01.01_GENERIC_002.045_001.zip';;
+ q) quiet_trigger=1;;
+ v) verbose_trigger=1;;
+ #*) echo "usage: $0 [-v] [-r]" >&2
+ #     exit 1 ;;
+ *) raise_error "invalid input: ${OPTARG}";;
+ esac
+done
+
+if [[ -z $get_modem_settings_trigger && -z $clear_modem_firmware_trigger && -z $download_modem_firmware_trigger && -z $flash_modem_firmware_trigger && -z $set_modem_settings_trigger && -z $set_swi_setusbcomp_trigger ]]; then
+  all_functions_trigger=1
+fi
+
+if [[ all_functions_trigger -eq 1 ]]; then
+  get_modem_settings_trigger=1
+  clear_modem_firmware_trigger=1
+  download_modem_firmware_trigger=1
+  flash_modem_firmware_trigger=1
+  set_modem_settings_trigger=1
+  set_swi_setusbcomp_trigger=1
+fi
+
+
+### Variables
 BLUE='\033[0;34m'
 NC='\033[0m' # No Color
+
+function display_variables {
+    echo "AT_USBSPEED=$AT_USBSPEED"
+    echo "AT_USBCOMP=$AT_USBCOMP"
+    echo "AT_SELRAT=$AT_SELRAT"
+    echo "AT_FASTENUMEN=$AT_FASTENUMEN"
+    echo "all_functions_trigger=$all_functions_trigger"
+    echo "get_modem_settings_trigger=$get_modem_settings_trigger"
+    echo "clear_modem_firmware_trigger=$clear_modem_firmware_trigger"
+    echo "download_modem_firmware_trigger=$download_modem_firmware_trigger"
+    echo "flash_modem_firmware_trigger=$flash_modem_firmware_trigger"
+    echo "set_modem_settings_trigger=$set_modem_settings_trigger"
+    echo "set_swi_setusbcomp_trigger=$set_swi_setusbcomp_trigger"
+    echo "SWI9X30C_CWE=$SWI9X30C_CWE"
+    echo "SWI9X30C_NVU=$SWI9X30C_NVU"
+    echo "AT_PRIID_STRING=$AT_PRIID_STRING"
+    echo "AT_PRIID_REV=$AT_PRIID_REV"
+    echo "AT_PRIID_VER=$AT_PRIID_VER"
+}
+
+# See if QMI desired, otherwise default to MBIM
+if [[ ${AT_USBCOMP^^} =~ QMI|6 ]]; then
+    echo 'Setting QMI Mode for Modem'
+    echo 'Interface bitmask: 0000010D (diag,nmea,modem,rmnet0)'
+    AT_USBCOMP="1,1,0000010D"
+    swi_usbcomp='6'
+else
+    echo 'Setting MBIM Mode for Modem'
+    echo 'Interface bitmask: 0000100D (diag,nmea,modem,mbim)'
+    AT_USBCOMP="1,1,0000100D"
+    swi_usbcomp='8'
+fi
+
+# Check for ALL/00 bands and set correct SELRAT/BAND, otherwise default to LTE
+if [[ ${AT_SELRAT^^} =~ ALL|^0$|^00$ ]]; then
+    AT_SELRAT='00'
+    AT_BAND='00'
+else
+    AT_SELRAT='06'
+    AT_BAND='09'
+fi
+
+# Check if valid FASTENUMEN mode, otherwise default to 2
+if [[ ! $AT_FASTENUMEN =~ ^[0-3]$ ]]; then
+    AT_FASTENUMEN=2
+fi
+
+
+FASTENUMEN_MODES="0 = Disable fast enumeration [Default]
+1 = Enable fast enumeration for cold boot and disable for warm boot
+2 = Enable fast enumeration for warm boot and disable for cold boot
+3 = Enable fast enumeration for warm and cold boot"
+echo '"FASTENUMEN"—Enable/disable fast enumeration for warm/cold boot.'
+echo -n 'Set mode: ' && echo "$FASTENUMEN_MODES" | grep -E "^$AT_FASTENUMEN"
+
+# Check desired USB interface mode, otherwise default to 0 (USB 2.0)
+if [[ ${AT_USBSPEED^^} =~ SUPER|USB3|1 ]]; then
+    AT_USBSPEED=1
+else
+    AT_USBSPEED=0
+fi
+
+
+### Pre-Checks
 
 if [ "$EUID" -ne 0 ]
     then echo "Please run with sudo"
     exit
 fi
 
-lsbrelease=`lsb_release -c | awk '{print $2}'`
+lsbrelease=$(lsb_release -c | awk '{print $2}')
 if [ "$lsbrelease" != "bionic" ]
     then echo "Please run on Ubuntu 18.04 LTS"
     lsb_release -a
     exit
 fi
 
-printf "${BLUE}---${NC}\n"
-echo 'Searching for EM7455/MC7455 USB modems...'
-modemcount=`lsusb | grep -i -E '1199:9071|1199:9079|413C:81B6' | wc -l`
-while [ $modemcount -eq 0 ]
-do
-    printf "${BLUE}---${NC}\n"
-    echo "Could not find any EM7455/MC7455 USB modems"
-    echo 'Unplug and reinsert the EM7455/MC7455 USB connector...'
-    modemcount=`lsusb | grep -i -E '1199:9071|1199:9079|413C:81B6' | wc -l`
+
+### Functions 
+function get_modem_deviceid {
+    deviceid=''
+    while [ -z $deviceid ]
+    do
+        echo 'Waiting for modem to reboot...'
+        sleep 3
+        deviceid=$(lsusb | grep -i -E '1199:9071|1199:9079|413C:81B6' | awk '{print $6}')
+    done
     sleep 3
-done
+    ttyUSB=$(dmesg | grep '.3: Qualcomm USB modem converter detected' -A1 | grep ttyUSB | sed 's/.*attached\ to\ //' | tail -1)
+    devpath=$(ls /dev | grep -E 'cdc-wdm|qcqmi')
+}
 
-printf "${BLUE}---${NC}\n"
-echo "Found EM7455/MC7455: 
-`lsusb | grep -i -E '1199:9071|1199:9079|413C:81B6'`
-"
-
-if [ $modemcount -gt 1 ]
-then 
+function reset_modem {
+    # Reset Modem
     printf "${BLUE}---${NC}\n"
-    echo "Found more than one EM7455/MC7455, remove the one you dont want to flash and try again."
-    exit
-fi
+    echo 'Reseting modem...'
+    ./swi_setusbcomp.pl --usbreset --device="/dev/$devpath" &>/dev/null
 
-# Stop modem manager to prevent AT command spam and allow firmware-update
-printf "${BLUE}---${NC}\n"
-echo 'Stoping modem manager to prevent AT command spam and allow firmware-update, this may take a minute...'
-systemctl stop ModemManager
-systemctl disable ModemManager
+}
 
-printf "${BLUE}---${NC}\n"
-echo "Installing all needed prerequisites..."
+function get_modem_settings {
+    # cat the serial port to monitor output and commands. cat will exit when AT!RESET kicks off.
+    sudo cat /dev/$ttyUSB 2>&1 | tee -a modem.log &  
 
-sudo add-apt-repository universe
-sudo apt update 
-# need make and GCC for compiling perl modules
-apt-get install make gcc curl minicom libqmi-glib5 libqmi-proxy libqmi-utils -y
-# Use cpan to install/compile all dependencies needed by swi_setusbcomp.pl
-yes | cpan install UUID::Tiny IPC::Shareable JSON
-
-# Install Modem Mode Switcher
-if [ ! -f swi_setusbcomp.pl ]; then
-    wget https://git.mork.no/wwan.git/plain/scripts/swi_setusbcomp.pl
-    chmod +x ./swi_setusbcomp.pl
-fi
-
-devpath=`ls /dev | grep -E 'cdc-wdm|qcqmi'`
-
-# Reset Modem
-printf "${BLUE}---${NC}\n"
-echo 'Reseting modem...'
-./swi_setusbcomp.pl --usbreset --device="/dev/$devpath" &>/dev/null
-sleep 3
-# Modem Mode Switch to usbcomp=8 (DM   NMEA  AT    MBIM)
-printf "${BLUE}---${NC}\n"
-echo 'Running Modem Mode Switch to usbcomp=8 (DM   NMEA  AT    MBIM)'
-./swi_setusbcomp.pl --usbcomp=8 --device="/dev/$devpath"
-
-# Reset Modem
-printf "${BLUE}---${NC}\n"
-echo 'Reseting modem...'
-./swi_setusbcomp.pl --usbreset --device="/dev/$devpath" &>/dev/null
-
-deviceid=''
-while [ -z $deviceid ]
-do
-    echo 'Waiting for modem to reboot...'
-    sleep 3
-    deviceid=`lsusb | grep -i -E '1199:9071|1199:9079|413C:81B6' | awk '{print $6}'`
-done
-
-sleep 5
-
-ttyUSB=`dmesg | grep '.3: Qualcomm USB modem converter detected' -A1 | grep ttyUSB | sed 's/.*attached\ to\ //' | tail -1`
-devpath=`ls /dev | grep -E 'cdc-wdm|qcqmi'`
-
-# cat the serial port to monitor output and commands. cat will exit when AT!RESET kicks off.
-sudo cat /dev/$ttyUSB 2>1 | tee -a modem.log &  
-
-# Display current modem settings
-printf "${BLUE}---${NC}\n"
-echo 'Current modem settings:'
-echo 'send AT
+    # Display current modem settings
+    printf "${BLUE}---${NC}\n"
+    echo 'Current modem settings:'
+    echo 'send AT
 send ATE1
 sleep 1
 send ATI
@@ -136,6 +233,10 @@ sleep 1
 send AT!IMPREF?
 sleep 1
 send AT!GOBIIMPREF?
+sleep 1
+send AT!USBSPEED?
+sleep 1
+send AT!USBSPEED=?
 sleep 1
 send AT!USBCOMP?
 sleep 1
@@ -163,109 +264,95 @@ send AT!CUSTOM?
 sleep 1
 send AT!IMAGE?
 sleep 1
+! pkill cat
+sleep 1
 ! pkill minicom
 ' > script.txt
+    sudo minicom -b 115200 -D /dev/$ttyUSB -S script.txt &>/dev/null
+}
 
-sudo minicom -b 115200 -D /dev/$ttyUSB -S script.txt &>/dev/null
-printf "${BLUE}---${NC}\n"
-while [[ ! $REPLY =~ ^[Yy]$ ]]
-do
-    read -p '
-Warning: This will overwrite all settings with generic EM7455/MC7455 Settings.
-Are you sure you want to continue? (CTRL+C to exit) ' -n 1 -r
-    if [[ $REPLY =~ ^[Nn]$ ]]
-    then
-        printf '\r\n'; break
-    fi
-done
-printf '\r\n'
-
-# Clear Previous PRI/FW Entries
-echo 'send AT!IMAGE=0
+function clear_modem_firmware {
+    # cat the serial port to monitor output and commands. cat will exit when AT!RESET kicks off.
+    sudo cat /dev/$ttyUSB 2>&1 | tee -a modem.log &  
+    # Clear Previous PRI/FW Entries
+    echo 'send AT
+send AT!IMAGE=0
 sleep 1
 send AT!IMAGE?
 sleep 1
+! pkill cat
+sleep 1
 ! pkill minicom
 ' > script.txt
-sudo minicom -b 115200 -D /dev/$ttyUSB -S script.txt &>/dev/null
+    sudo minicom -b 115200 -D /dev/$ttyUSB -S script.txt &>/dev/null
+}
 
-# Reset Modem
-printf "${BLUE}---${NC}\n"
-echo 'Reseting modem...'
-./swi_setusbcomp.pl --usbreset --device="/dev/$devpath" &>/dev/null
+function download_modem_firmware {
+    # Find latest 7455 firmware and download it
+    if [[ -z $SWI9X30C_ZIP ]]; then
+        SWI9X30C_ZIP=$(curl https://source.sierrawireless.com/resources/airprime/minicard/74xx/airprime-em_mc74xx-approved-fw-packages/ 2> /dev/null | grep PTCRB -B1 | grep -iEo '7455/swi9x30c[_0-9.]+_generic_[_0-9.]+' | cut -c 6- | tail -n1)
+        SWI9X30C_ZIP="${SWI9X30C_ZIP^^}"'zip'
+    fi
+    SWI9X30C_URL='https://source.sierrawireless.com/~/media/support_downloads/airprime/74xx/fw/7455/'"$SWI9X30C_ZIP"
 
-# Find latest 7455 firmware and download it
-SWI9X30C_ZIP=`curl https://source.sierrawireless.com/resources/airprime/minicard/74xx/airprime-em_mc74xx-approved-fw-packages/ 2> /dev/null | grep PTCRB -B1 | grep -iEo '7455/swi9x30c[_0-9.]+_generic_[_0-9.]+' | cut -c 6- | tail -n1`
-SWI9X30C_ZIP="$SWI9X30C_ZIP"'zip'
+    SWI9X30C_LENGTH=$(curl -sI $SWI9X30C_URL | grep -i Content-Length | grep -Eo '[0-9]+')
 
-SWI9X30C_URL='https://source.sierrawireless.com/~/media/support_downloads/airprime/74xx/fw/7455/'"$SWI9X30C_ZIP"
+    # If remote file size is less than 40MiB, something went wrong, exit.
+    if [[ $SWI9X30C_LENGTH -lt 40000000 ]]; then
+        printf "${BLUE}---${NC}\n"
+        printf "Download of ${BLUE}$SWI9X30C_ZIP${NC} failed.\nFile size on server is too small, something is wrong, exiting...\n"
+        printf "Attempted download URL was: $SWI9X30C_URL\n"
+        printf "curl info:\n"
+        curl -sI $SWI9X30C_URL
+        printf "${BLUE}---${NC}\n"
+        exit
+    fi
 
-SWI9X30C_LENGTH=`curl -sI $SWI9X30C_URL | grep -i Content-Length | grep -Eo '[0-9]+'`
+    if [[ $SWI9X30C_LENGTH -eq $(stat --printf="%s" $SWI9X30C_ZIP 2>/dev/null) ]]; then
+        echo "Already downloaded $SWI9X30C_ZIP..."
+    else
+        echo "Downloading $SWI9X30C_URL"
+        curl -o $SWI9X30C_ZIP $SWI9X30C_URL
+    fi
 
-# If remote file size is less than 40MiB, something went wrong, exit.
-if [[ $SWI9X30C_LENGTH -lt 40000000 ]]; then
+    # If download size does not match what server says, exit:
+    if [[ $SWI9X30C_LENGTH -ne $(stat --printf="%s" $SWI9X30C_ZIP 2>/dev/null) ]]; then
+        printf "${BLUE}---${NC}\n"
+        printf "Download of ${BLUE}$SWI9X30C_ZIP${NC} failed.\nDownloaded file size is inconsistent with server, exiting...\n"
+        printf "${BLUE}---${NC}\n"
+        exit
+    fi
+
+    # Cleanup old CWE/NVUs
+    rm -f *.cwe *.nvu 2>/dev/null
+    
+    # Unzip SWI9X30C, force overwrite
+    unzip -o "$SWI9X30C_ZIP"
+}
+
+function flash_modem_firmware {
+    #Kill cat processes used for monitoring status, if it hasnt already exited
+    sudo pkill -9 cat &>/dev/null
+
     printf "${BLUE}---${NC}\n"
-    printf "Download of ${BLUE}$SWI9X30C_ZIP${NC} failed.\nFile size on server is too small, something is wrong, exiting...\n"
-    printf "Attempted download URL was: $SWI9X30C_URL\n"
-    printf "curl info:\n"
-    curl -sI $SWI9X30C_URL
-    printf "${BLUE}---${NC}\n"
-    exit
-fi
+    echo "Flashing $SWI9X30C_CWE onto Generic Sierra Modem..."
+    sleep 5
+    qmi-firmware-update --update -d "$deviceid" "$SWI9X30C_CWE" "$SWI9X30C_NVU"
+    rc=$?
+    if [[ $rc != 0 ]]
+    then
+        echo "Firmware Update failed, exiting..."
+        exit $rc
+    fi
+}
 
-echo "Downloading $SWI9X30C_URL"
-curl -O $SWI9X30C_URL
+function set_modem_settings {
+    # cat the serial port to monitor output and commands. cat will exit when AT!RESET kicks off.
+    sudo cat /dev/$ttyUSB 2>1 | tee -a modem.log &  
 
-# If download size does not match what server says, exit:
-if [ $SWI9X30C_LENGTH -ne `stat --printf="%s" $SWI9X30C_ZIP` ]; then
-    printf "${BLUE}---${NC}\n"
-    printf "Download of ${BLUE}$SWI9X30C_ZIP${NC} failed.\nDownloaded file size is inconsistent with server, exiting...\n"
-    printf "${BLUE}---${NC}\n"
-    exit
-fi
-
-# Unzip SWI9X30C, force overwrite
-unzip -o "$SWI9X30C_ZIP"
-
-SWI9X30C_CWE=`find -maxdepth 1 -type f -iregex '.*SWI9X30C[0-9_.]+\.cwe' | cut -c 3- | tail -n1`
-SWI9X30C_NVU=`find -maxdepth 1 -type f -iregex '.*SWI9X30C[0-9_.]+generic[0-9_.]+\.nvu' | cut -c 3- | tail -n1`
-
-deviceid=`lsusb | grep -i -E '1199:9071|1199:9079|413C:81B6' | awk '{print $6}'`
-while [ -z $deviceid ]
-do
-    echo 'Waiting for modem to reboot...'
-    sleep 3
-    deviceid=`lsusb | grep -i -E '1199:9071|1199:9079|413C:81B6' | awk '{print $6}'`
-done
-#Kill cat processes used for monitoring status, if it hasnt already exited
-sudo pkill -9 cat &>/dev/null
-
-printf "${BLUE}---${NC}\n"
-echo "Flashing $SWI9X30C_CWE onto Generic Sierra Modem..."
-sleep 5
-qmi-firmware-update --update -d "$deviceid" "$SWI9X30C_CWE" "$SWI9X30C_NVU"
-rc=$?
-if [[ $rc != 0 ]]
-then
-    echo "Firmware Update failed, exiting..."
-    exit $rc
-fi
-
-deviceid=''
-while [ -z $deviceid ]
-do
-    echo 'Waiting for modem to reboot...'
-    sleep 3
-    deviceid=`lsusb | grep -i -E '1199:9071|1199:9079|413C:81B6' | awk '{print $6}'`
-done
-
-# cat the serial port to monitor output and commands. cat will exit when AT!RESET kicks off.
-sudo cat /dev/$ttyUSB 2>1 | tee -a modem.log &  
-
-# Set Generic Sierra Wireless VIDs/PIDs
-if [[ $REPLY =~ ^[Yy]$ ]]
-then
-    echo 'send AT
+    # Set Generic Sierra Wireless VIDs/PIDs
+    cat <<EOF > script.txt
+send AT
 send ATE1
 sleep 1
 send ATI
@@ -276,7 +363,7 @@ send AT!IMPREF=\"GENERIC\"
 sleep 1
 send AT!GOBIIMPREF=\"GENERIC\"
 sleep 1
-send AT!USBCOMP=1,1,0000100D
+send AT!USBCOMP=$AT_USBCOMP
 sleep 1
 send AT!USBVID=1199
 sleep 1
@@ -284,21 +371,23 @@ send AT!USBPID=9071,9070
 sleep 1
 send AT!USBPRODUCT=\"EM7455\"
 sleep 1
-send AT!PRIID=\"9904609\",\"002.030\",\"Generic-Laptop\"
+send AT!PRIID=\"$AT_PRIID_REV\",\"$AT_PRIID_VER\",\"Generic-Laptop\"
 sleep 1
-send AT!SELRAT=06
+send AT!SELRAT=$AT_SELRAT
 sleep 1
-send AT!BAND=00
+send AT!BAND=$AT_BAND
 sleep 1
-send AT!CUSTOM=\"FASTENUMEN\",2
+send AT!CUSTOM=\"FASTENUMEN\",$AT_FASTENUMEN
 sleep 1
 send AT!PCOFFEN=2
 sleep 1
 send AT!PCOFFEN?
 sleep 1
+send AT!USBSPEED=$AT_USBSPEED
+sleep 1
 send AT!USBSPEED?
 sleep 1
-send AT!USBSPEED=0
+send AT!USBSPEED=?
 sleep 1
 send AT!CUSTOM?
 sleep 1
@@ -308,15 +397,113 @@ send AT!PCINFO?
 sleep 1
 send AT!RESET
 ! pkill minicom
-' > script.txt
+EOF
     sudo minicom -b 115200 -D /dev/$ttyUSB -S script.txt &>/dev/null
+}
+
+function script_prechecks {
+    printf "${BLUE}---${NC}\n"
+    echo 'Searching for EM7455/MC7455 USB modems...'
+    modemcount=$(lsusb | grep -i -E '1199:9071|1199:9079|413C:81B6' | wc -l)
+    while [ $modemcount -eq 0 ]
+    do
+        printf "${BLUE}---${NC}\n"
+        echo "Could not find any EM7455/MC7455 USB modems"
+        echo 'Unplug and reinsert the EM7455/MC7455 USB connector...'
+        modemcount=$(lsusb | grep -i -E '1199:9071|1199:9079|413C:81B6' | wc -l)
+        sleep 3
+    done
+
+    printf "${BLUE}---${NC}\n"
+    echo "Found EM7455/MC7455: 
+    $(lsusb | grep -i -E '1199:9071|1199:9079|413C:81B6')
+    "
+
+    if [ $modemcount -gt 1 ]
+    then 
+        printf "${BLUE}---${NC}\n"
+        echo "Found more than one EM7455/MC7455, remove the one you dont want to flash and try again."
+        exit
+    fi
+
+    # Stop modem manager to prevent AT command spam and allow firmware-update
+    printf "${BLUE}---${NC}\n"
+    echo 'Stoping modem manager to prevent AT command spam and allow firmware-update, this may take a minute...'
+    systemctl stop ModemManager
+    systemctl disable ModemManager
+
+    printf "${BLUE}---${NC}\n"
+    echo "Installing all needed prerequisites..."
+    add-apt-repository universe 1>/dev/null
+    apt update -y
+    # need make and GCC for compiling perl modules
+    apt-get install make gcc curl minicom libqmi-glib5 libqmi-proxy libqmi-utils -y
+    # Use cpan to install/compile all dependencies needed by swi_setusbcomp.pl
+    yes | cpan install UUID::Tiny IPC::Shareable JSON
+    reset_modem
+}
+
+
+function set_swi_setusbcomp {
+    # Install Modem Mode Switcher
+    if [ ! -f swi_setusbcomp.pl ]; then
+        wget https://git.mork.no/wwan.git/plain/scripts/swi_setusbcomp.pl
+    fi
+    chmod +x ./swi_setusbcomp.pl
+    
+    # Modem Mode Switch to usbcomp=8 (DM   NMEA  AT    MBIM)
+    printf "${BLUE}---${NC}\n"
+    echo 'Running Modem Mode Switch to usbcomp=8 (DM   NMEA  AT    MBIM)'
+    ./swi_setusbcomp.pl --usbcomp=$swi_usbcomp --device="/dev/$devpath"
+    reset_modem
+}
+
+
+function script_cleanup {
+    # Restart ModemManager
+    systemctl enable ModemManager &>/dev/null
+    systemctl start ModemManager &>/dev/null
+
+    echo "Done!"
+
+    # Kill cat processes used for monitoring status, if it hasnt already exited
+    sudo pkill -9 cat &>/dev/null
+}
+
+### Script Execution
+if [[ $quiet_trigger ]]; then
+    script_prechecks &>/dev/null
+else
+    script_prechecks
 fi
 
-#Done, restart ModemManager
-systemctl enable ModemManager &>/dev/null
-systemctl start ModemManager &>/dev/null
+devpath=$(ls /dev | grep -E 'cdc-wdm|qcqmi')
 
-echo "Done!"
 
-#Kill cat processes used for monitoring status, if it hasnt already exited
-sudo pkill -9 cat &>/dev/null
+if [[ $set_swi_setusbcomp_trigger ]]; then
+    set_swi_setusbcomp
+fi
+
+get_modem_deviceid
+
+[[ $get_modem_settings_trigger ]] && get_modem_settings
+
+if [[ $clear_modem_firmware_trigger ]]; then
+  clear_modem_firmware
+  get_modem_deviceid
+fi
+
+[[ $download_modem_firmware_trigger ]] && download_modem_firmware
+
+SWI9X30C_CWE=$(find -maxdepth 1 -type f -iregex '.*SWI9X30C[0-9_.]+\.cwe' | cut -c 3- | tail -n1)
+SWI9X30C_NVU=$(find -maxdepth 1 -type f -iregex '.*SWI9X30C[0-9_.]+generic[0-9_.]+\.nvu' | cut -c 3- | tail -n1)
+
+AT_PRIID_STRING=$(strings "$SWI9X30C_NVU" | grep '^9999999_.*_SWI9X30C_' | sort -u | head -1)
+AT_PRIID_REV="$(echo $AT_PRIID_STRING | awk -F'_' '{print $2}')"
+AT_PRIID_VER="$(echo $AT_PRIID_STRING | grep -Eo '[0-9]{3}\.[0-9]{3}')"
+
+[[ $flash_modem_firmware_trigger ]] && flash_modem_firmware
+[[ $set_modem_settings_trigger ]] && set_modem_settings
+[[ $verbose_trigger ]] && display_variables
+
+script_cleanup

--- a/autoflash-7455.sh
+++ b/autoflash-7455.sh
@@ -98,6 +98,26 @@ do
   esac
 done
 
+##################
+### Pre-Checks ###
+##################
+
+if [ "$EUID" -ne 0 ]
+    then echo "Please run with sudo"
+    exit
+fi
+
+lsbrelease=$(lsb_release -c | awk '{print $2}')
+if [ "$lsbrelease" != "bionic" ]
+    then echo "Please run on Ubuntu 18.04 LTS"
+    lsb_release -a
+    exit
+fi
+
+#################
+### Functions ###
+#################
+
 # If no options are set, use defaults of -Mgcdfs
 if [[ -z $get_modem_settings_trigger && -z $clear_modem_firmware_trigger \
     && -z $download_modem_firmware_trigger && -z $flash_modem_firmware_trigger \
@@ -176,23 +196,6 @@ function set_options() {
     fi
 }
 
-
-### Pre-Checks
-
-if [ "$EUID" -ne 0 ]
-    then echo "Please run with sudo"
-    exit
-fi
-
-lsbrelease=$(lsb_release -c | awk '{print $2}')
-if [ "$lsbrelease" != "bionic" ]
-    then echo "Please run on Ubuntu 18.04 LTS"
-    lsb_release -a
-    exit
-fi
-
-
-### Functions 
 function get_modem_deviceid() {
     deviceid=''
     while [ -z $deviceid ]

--- a/autoflash-7455.sh
+++ b/autoflash-7455.sh
@@ -132,12 +132,12 @@ function display_variables {
     echo "SWI9X30C_CWE=$SWI9X30C_CWE"
     echo "SWI9X30C_NVU=$SWI9X30C_NVU"
     echo "AT_PRIID_STRING=$AT_PRIID_STRING"
+    echo "AT_PRIID_PN=$AT_PRIID_PN"
     echo "AT_PRIID_REV=$AT_PRIID_REV"
-    echo "AT_PRIID_VER=$AT_PRIID_VER"
 }
 
 # See if QMI desired, otherwise default to MBIM
-if [[ ${AT_USBCOMP^^} =~ QMI|6 ]]; then
+if [[ ${AT_USBCOMP^^} =~ ^QMI$|^6$ ]]; then
     echo 'Setting QMI Mode for Modem'
     echo 'Interface bitmask: 0000010D (diag,nmea,modem,rmnet0)'
     AT_USBCOMP="1,1,0000010D"
@@ -150,7 +150,7 @@ else
 fi
 
 # Check for ALL/00 bands and set correct SELRAT/BAND, otherwise default to LTE
-if [[ ${AT_SELRAT^^} =~ ALL|^0$|^00$ ]]; then
+if [[ ${AT_SELRAT^^} =~ ^ALL$|^0$|^00$ ]]; then
     AT_SELRAT='00'
     AT_BAND='00'
 else
@@ -163,13 +163,12 @@ if [[ ! $AT_FASTENUMEN =~ ^[0-3]$ ]]; then
     AT_FASTENUMEN=2
 fi
 
-
-FASTENUMEN_MODES="0 = Disable fast enumeration [Default]
-1 = Enable fast enumeration for cold boot and disable for warm boot
-2 = Enable fast enumeration for warm boot and disable for cold boot
-3 = Enable fast enumeration for warm and cold boot"
-echo '"FASTENUMEN"—Enable/disable fast enumeration for warm/cold boot.'
-echo -n 'Set mode: ' && echo "$FASTENUMEN_MODES" | grep -E "^$AT_FASTENUMEN"
+#FASTENUMEN_MODES="0 = Disable fast enumeration [Default]
+#1 = Enable fast enumeration for cold boot and disable for warm boot
+#2 = Enable fast enumeration for warm boot and disable for cold boot
+#3 = Enable fast enumeration for warm and cold boot"
+#echo '"FASTENUMEN"—Enable/disable fast enumeration for warm/cold boot.'
+#echo -n 'Set mode: ' && echo "$FASTENUMEN_MODES" | grep -E "^$AT_FASTENUMEN"
 
 # Check desired USB interface mode, otherwise default to 0 (USB 2.0)
 if [[ ${AT_USBSPEED^^} =~ SUPER|USB3|1 ]]; then
@@ -371,7 +370,7 @@ send AT!USBPID=9071,9070
 sleep 1
 send AT!USBPRODUCT=\"EM7455\"
 sleep 1
-send AT!PRIID=\"$AT_PRIID_REV\",\"$AT_PRIID_VER\",\"Generic-Laptop\"
+send AT!PRIID=\"$AT_PRIID_PN\",\"$AT_PRIID_REV\",\"Generic-Laptop\"
 sleep 1
 send AT!SELRAT=$AT_SELRAT
 sleep 1
@@ -499,8 +498,8 @@ SWI9X30C_CWE=$(find -maxdepth 1 -type f -iregex '.*SWI9X30C[0-9_.]+\.cwe' | cut 
 SWI9X30C_NVU=$(find -maxdepth 1 -type f -iregex '.*SWI9X30C[0-9_.]+generic[0-9_.]+\.nvu' | cut -c 3- | tail -n1)
 
 AT_PRIID_STRING=$(strings "$SWI9X30C_NVU" | grep '^9999999_.*_SWI9X30C_' | sort -u | head -1)
-AT_PRIID_REV="$(echo $AT_PRIID_STRING | awk -F'_' '{print $2}')"
-AT_PRIID_VER="$(echo $AT_PRIID_STRING | grep -Eo '[0-9]{3}\.[0-9]{3}')"
+AT_PRIID_PN="$(echo $AT_PRIID_STRING | awk -F'_' '{print $2}')"
+AT_PRIID_REV="$(echo $AT_PRIID_STRING | grep -Eo '[0-9]{3}\.[0-9]{3}')"
 
 [[ $flash_modem_firmware_trigger ]] && flash_modem_firmware
 [[ $set_modem_settings_trigger ]] && set_modem_settings

--- a/autoflash-7455.sh
+++ b/autoflash-7455.sh
@@ -31,8 +31,10 @@
 #.VERSION
 # Version: master
 
+### Variables
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
 
-#echo "Starting sctipt $0"
 function display_usage() {
   echo
   echo "Usage: $0"
@@ -66,7 +68,7 @@ function display_usage() {
   echo " -l    Legacy Stable Firmware"
   echo '         Set SWI9X30C_ZIP="SWI9X30C_02.30.01.01_GENERIC_002.045_001.zip"'
   echo " -q    Quiet Mode -- suppress most output"
-  echo " -v    Legacy Stable Firmware"
+  echo " -v    Verbose/Debug Mode"
   echo
   exit 0
 }
@@ -96,8 +98,11 @@ do
   esac
 done
 
-if [[ -z $get_modem_settings_trigger && -z $clear_modem_firmware_trigger && -z $download_modem_firmware_trigger && -z $flash_modem_firmware_trigger && -z $set_modem_settings_trigger && -z $set_swi_setusbcomp_trigger ]]; then
-  all_functions_trigger=1
+# If no options are set, use defaults of -Mgcdfs
+if [[ -z $get_modem_settings_trigger && -z $clear_modem_firmware_trigger \
+    && -z $download_modem_firmware_trigger && -z $flash_modem_firmware_trigger \
+    && -z $set_modem_settings_trigger && -z $set_swi_setusbcomp_trigger ]]; then
+        all_functions_trigger=1
 fi
 
 if [[ all_functions_trigger -eq 1 ]]; then
@@ -108,11 +113,6 @@ if [[ all_functions_trigger -eq 1 ]]; then
   set_modem_settings_trigger=1
   set_swi_setusbcomp_trigger=1
 fi
-
-
-### Variables
-BLUE='\033[0;34m'
-NC='\033[0m' # No Color
 
 function display_variables() {
     echo "AT_USBSPEED=$AT_USBSPEED"
@@ -447,7 +447,6 @@ function script_prechecks() {
     reset_modem
 }
 
-
 function set_swi_setusbcomp() {
     # Modem Mode Switch to usbcomp=8 (DM   NMEA  AT    MBIM)
     printf "${BLUE}---${NC}\n"
@@ -455,7 +454,6 @@ function set_swi_setusbcomp() {
     ./swi_setusbcomp.pl --usbcomp=$swi_usbcomp --device="$devpath"
     reset_modem
 }
-
 
 function script_cleanup() {
     # Restart ModemManager
@@ -468,7 +466,10 @@ function script_cleanup() {
     sudo pkill -9 cat &>/dev/null
 }
 
-### Script Execution
+########################
+### Script Execution ###
+########################
+
 if [[ $quiet_trigger ]]; then
     script_prechecks &>/dev/null
 else
@@ -506,3 +507,5 @@ AT_PRIID_REV="$(echo "$AT_PRIID_STRING" | grep -Eo '[0-9]{3}\.[0-9]{3}')"
 [[ $verbose_trigger ]] && display_variables
 
 script_cleanup
+
+# Done


### PR DESCRIPTION
```bash
Usage: autoflash-7455.sh

Modem Modes:
 -h    Display usage instructions
 -u    Set AT!USBSPEED
         0 - High Speed USB 2 [Default]
         1 - SuperSpeed USB 3
 -m    Set AT!USBCOMP
         8 - MBIM mode (diag,nmea,modem,mbim) [Default]
         6 - QMI mode (diag,nmea,modem,rmnet0)
 -b    Set AT!SELRAT and AT!BAND
         9 - LTE Only [Default]
         0 - All Bands
 -e    Set AT!FASTENUMEN
         0 - Disable fast enumeration
         1 - Enable fast enumeration for cold boot and disable for warm boot
         2 - Enable fast enumeration for warm boot and disable for cold boot [Default]
         3 - Enable fast enumeration for warm and cold boot

Script Modes:
 -a    Enable All Script Functions [Default]
         Same as: autoflash-7455.sh -Mgcdfs
 -M    Use swi_setusbcomp.pl to set modem composition
 -g    Display Modem Settings
 -c    Clear Existing Modem Firmwares
 -d    Download and Unpack Modem Firmware from Sierra Wireless
 -f    Flash Modem Firmware
 -s    Change Modem Settings/Modes
 -l    Legacy Stable Firmware
         Set SWI9X30C_ZIP="SWI9X30C_02.30.01.01_GENERIC_002.045_001.zip"
 -q    Quiet Mode -- suppress most output
 -v    Verbose/Debug Mode
```