### PR TITLE
README.md: clarify Lenovo whitelist workaround

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@
 Note: [Use a $10 M.2 USB Adapter to flash and configure the modem](https://www.ebay.com/sch/i.html?_from=R40&_nkw=ngff+sim+usb&_sacat=0&_sop=15)
 1. Enable Advanced Commands:
     + `AT!ENTERCND="A710"`
-2. Skip bootloader mode on warm-boots.
+2. Do not skip full initialization on cold boots.
     + `AT!CUSTOM="FASTENUMEN",2`
     + Prevents device from showing up until it has been fully initialized. This causes the modem to stealth bypass BIOS whitelists as it will not show up until a few seconds after the BIOS has completed its checks.
 3. Tell the modem to ignore the W_DISABLE pin sent by many laptop's internal M2 slots.


### PR DESCRIPTION
The point of the `AT!CUSTOM="FASTENUMEN",x` change is not to "skip <...> on warm-boots", but rather to disable this behavior on cold boots (so that the modem takes more time to initialize).

Also I'm not sure that it's the bootloader mode we're skipping. As far as I can see, in either case it shows up directly in normal (application) mode, it just takes more time to do that with `FASTENUMEN=0|2`. Hence cnanged that bit too.