### PR TITLE
Update autoflash-7455.sh

### DIFF
--- a/autoflash-7455.sh
+++ b/autoflash-7455.sh
@@ -293,10 +293,10 @@ sleep 1
 function download_modem_firmware() {
     # Find latest 7455 firmware and download it
     if [[ -z $SWI9X30C_ZIP ]]; then
-        SWI9X30C_ZIP=$(curl https://source.sierrawireless.com/resources/airprime/minicard/74xx/airprime-em_mc74xx-approved-fw-packages/ 2> /dev/null | grep PTCRB -B1 | grep -iEo '7455/swi9x30c[_0-9.]+_generic_[_0-9.]+' | cut -c 6- | tail -n1)
+        SWI9X30C_ZIP=$(curl https://source.sierrawireless.com/-/media/support_downloads/airprime/74xx/fw/7455/ 2> /dev/null | grep PTCRB -B1 | grep -iEo '7455/swi9x30c[_0-9.]+_generic_[_0-9.]+' | cut -c 6- | tail -n1)
         SWI9X30C_ZIP="${SWI9X30C_ZIP^^}"'zip'
     fi
-    SWI9X30C_URL='https://source.sierrawireless.com/~/media/support_downloads/airprime/74xx/fw/7455/'"$SWI9X30C_ZIP"
+    SWI9X30C_URL='https://source.sierrawireless.com/-/media/support_downloads/airprime/74xx/fw/7455/'"$SWI9X30C_ZIP"
 
     SWI9X30C_LENGTH=$(curl -sI "$SWI9X30C_URL" | grep -i Content-Length | grep -Eo '[0-9]+')
 


### PR DESCRIPTION
updated URL link to  Generic Firmware: SWI9X30C_02.33.03.00 and PRI: 002.072_000 (as of September 12, 2020)
https://source.sierrawireless.com/-/media/support_downloads/airprime/74xx/fw/7455/swi9x30c_02,-d-,33,-d-,03,-d-,00_generic_002,-d-,072_000.ashx
Lines Changed: 296 and 299
Sierra Wireless link approved firmware packages: https://source.sierrawireless.com/resources/airprime/minicard/74xx/airprime-em_mc74xx-approved-fw-packages/#sthash.FBaygqrY.dpbs