### PR TITLE
Patch for Sierra changing the URL format

### DIFF
--- a/autoflash-7455.sh
+++ b/autoflash-7455.sh
@@ -29,7 +29,7 @@
 # https://github.com/danielewood/sierra-wireless-modems
 
 #.VERSION
-# Version: 20190724
+# Version: 20200912
 
 ##################
 ### Pre-Checks ###
@@ -293,7 +293,7 @@ sleep 1
 function download_modem_firmware() {
     # Find latest 7455 firmware and download it
     if [[ -z $SWI9X30C_ZIP ]]; then
-        SWI9X30C_ZIP=$(curl https://source.sierrawireless.com/resources/airprime/minicard/74xx/airprime-em_mc74xx-approved-fw-packages/ 2> /dev/null | grep PTCRB -B1 | grep -iEo '7455/swi9x30c[_0-9.]+_generic_[_0-9.]+' | cut -c 6- | tail -n1)
+        SWI9X30C_ZIP=$(curl https://source.sierrawireless.com/resources/airprime/minicard/74xx/airprime-em_mc74xx-approved-fw-packages/ 2> /dev/null | grep PTCRB -B1 | sed 's/,-d-,/./g' | grep -iEo '7455/swi9x30c[_0-9.]+_generic_[_0-9.]+' | cut -c 6- | tail -n1)
         SWI9X30C_ZIP="${SWI9X30C_ZIP^^}"'zip'
     fi
     SWI9X30C_URL='https://source.sierrawireless.com/~/media/support_downloads/airprime/74xx/fw/7455/'"$SWI9X30C_ZIP"


### PR DESCRIPTION
Sierra changed presented URL to have `,-d-,` instead of periods. Added sed to put them back.

The filename on the backend is unchanged, example:
```bash
SWI9X30C_ZIP=$(curl https://source.sierrawireless.com/resources/airprime/minicard/74xx/airprime-em_mc74xx-approved-fw-packages/ 2> /dev/null | grep PTCRB -B1 | sed 's/,-d-,/./g' | grep -iEo '7455/swi9x30c[_0-9.]+_generic_[_0-9.]+' | cut -c 6- | tail -n1)
SWI9X30C_ZIP="${SWI9X30C_ZIP^^}"'zip'
SWI9X30C_URL='https://source.sierrawireless.com/~/media/support_downloads/airprime/74xx/fw/7455/'"$SWI9X30C_ZIP"

ubuntu@ubuntu20:~$ curl -sI "$SWI9X30C_URL"
HTTP/1.1 200 OK
Cache-Control: private, max-age=604800
Content-Length: 63701793
Content-Type: application/x-zip-compressed
Last-Modified: Sun, 13 Oct 2019 06:30:47 GMT
Accept-Ranges: bytes
Server: Microsoft-IIS/10.0
Content-Disposition: attachment; filename="SWI9X30C_02.33.03.00_Generic_002.072_000.zip"
Access-Control-Allow-Origin: *
Access-Control-Allow-Headers: Origin, X-Requested-With, Content-Type, Accept
Date: Sat, 12 Sep 2020 19:51:50 GMT
Set-Cookie: BIGipServer~SWI_CORP_WWW~SWI_CORP_CAKEL-HTTPS=911934474.47873.0000; path=/; Httponly; Secure
```
Highlight: `Content-Disposition: attachment; filename="SWI9X30C_02.33.03.00_Generic_002.072_000.zip"`