### PR TITLE
autoflash-7455.sh: update min Ubuntu version check

### DIFF
--- a/autoflash-7455.sh
+++ b/autoflash-7455.sh
@@ -40,8 +40,8 @@ if [ "$EUID" -ne 0 ]
     exit
 fi
 
-if [[ $(lsb_release -r | awk '{print ($2 >= "18.04")}') -eq 0 ]]; then 
-    echo "Please run on Ubuntu 18.04 (Bionic) or later"
+if [[ $(lsb_release -r | awk '{print ($2 >= "20.04")}') -eq 0 ]]; then 
+    echo "Please run on Ubuntu 20.04 (Focal Fossa) or later"
     lsb_release -a
     exit
 fi


### PR DESCRIPTION
because if both script synopsis and description say "Only for use on Ubuntu 20.04 (or later) LiveUSB"
that has got to mean that checking for Ubuntu 18.04 or later is not good anymore.

Also the script fails in Ubuntu 18.04, firmware download commands are different, while it works fine in 20.04.

Therefore, update the check