### PR TITLE
update command to grab latest firmware

### DIFF
--- a/autoflash-7455.sh
+++ b/autoflash-7455.sh
@@ -305,7 +305,7 @@ sleep 1
 function download_modem_firmware() {
     # Find latest 7455 firmware and download it
     if [[ -z $SWI9X30C_ZIP ]]; then
-        SWI9X30C_URL=$(curl -s https://source.sierrawireless.com/resources/airprime/minicard/74xx/em_mc74xx-approved-fw-packages/ 2>/dev/null | grep 'GCF Approved' -B1 | grep '7455' | sed 's/,-d-,/./g' | grep -iPo 'href="\K.+/swi9x30c[_0-9.]+_generic_[_0-9.]+' | tail -n1)
+        SWI9X30C_URL=$(curl -s https://source.sierrawireless.com/resources/airprime/minicard/74xx/em_mc74xx-approved-fw-packages/ 2>/dev/null | grep 'GCF Approved' -B4 | grep '7455' | sed 's/,-d-,/./g' | grep -iPo 'href="\K.+/swi9x30c[_0-9.]+_generic_[_0-9.]+' | tail -n1)
         SWI9X30C_ZIP=${SWI9X30C_URL##*/}
         SWI9X30C_ZIP="${SWI9X30C_ZIP^^}"'zip'
     fi


### PR DESCRIPTION
Closes #159

https://github.com/danielewood/sierra-wireless-modems/issues/159#issuecomment-2791334296 mentioned that if you change it to -B4 it will correctly grab the latest version of the firmware

This PR includes that change 